### PR TITLE
Change dynamic import to readFile

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,9 +24,7 @@ const uriToDBConfig = (uri: string) => {
 export const runTypeGenerator = async () => {
   const args = parse(Deno.args);
 
-  const { default: normConfig } = await import(normConfigFile, {
-    assert: { type: 'json' },
-  });
+  const normConfig = JSON.parse(await Deno.readTextFile(normConfigFile));
 
   const parsedConfig = normConfigSchema.parse(normConfig, {});
 


### PR DESCRIPTION
This PR changes the dynamic import used in loading the config file to read and parse as text file instead to allow usage of resolved path