### PR TITLE
Implement recursive filter

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -532,8 +532,8 @@
     "specifiers": {
       "cpy-cli@^4.2.0": "cpy-cli@4.2.0",
       "pg-connection-string@2.5.0": "pg-connection-string@2.5.0",
-      "pg-structure": "pg-structure@7.14.0",
-      "pg-structure@^7.13.1": "pg-structure@7.14.0",
+      "pg-structure": "pg-structure@7.13.1",
+      "pg-structure@^7.13.1": "pg-structure@7.13.1",
       "zod": "zod@3.21.4",
       "zod@^3.20.6": "zod@3.21.4"
     },
@@ -1029,10 +1029,6 @@
         "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
         "dependencies": {}
       },
-      "pg-pool@3.5.2": {
-        "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
-        "dependencies": {}
-      },
       "pg-pool@3.5.2_pg@8.9.0": {
         "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
         "dependencies": {
@@ -1045,20 +1041,6 @@
       },
       "pg-structure@7.13.1": {
         "integrity": "sha512-iDdBkWCcOK3fUWtdIfkrH06CNXZXL/R+rhDl4qQrMIXvrFckzzHax4bfSAFw39xwBXaijdvqA/Hyj655SKjlYA==",
-        "dependencies": {
-          "@typescript-plus/fast-memoize-decorator": "@typescript-plus/fast-memoize-decorator@0.1.0",
-          "dotenv": "dotenv@8.6.0",
-          "fast-memoize": "fast-memoize@2.5.2",
-          "indexable-array": "indexable-array@0.7.0",
-          "inflection": "inflection@1.13.4",
-          "json5": "json5@2.2.3",
-          "lodash.get": "lodash.get@4.4.2",
-          "pg": "pg@8.9.0",
-          "pg-connection-string": "pg-connection-string@2.5.0"
-        }
-      },
-      "pg-structure@7.14.0": {
-        "integrity": "sha512-Rq0IXxzRfK2KFYopjbJQKhKvWlcufzyG8wtFsR+2ncXl5NSg3YsQw1ODicIAtiU1vYFIdt/P3iQcGmJ/UrT6DQ==",
         "dependencies": {
           "@typescript-plus/fast-memoize-decorator": "@typescript-plus/fast-memoize-decorator@0.1.0",
           "dotenv": "dotenv@8.6.0",

--- a/deno.lock
+++ b/deno.lock
@@ -532,8 +532,8 @@
     "specifiers": {
       "cpy-cli@^4.2.0": "cpy-cli@4.2.0",
       "pg-connection-string@2.5.0": "pg-connection-string@2.5.0",
-      "pg-structure": "pg-structure@7.13.1",
-      "pg-structure@^7.13.1": "pg-structure@7.13.1",
+      "pg-structure": "pg-structure@7.14.0",
+      "pg-structure@^7.13.1": "pg-structure@7.14.0",
       "zod": "zod@3.21.4",
       "zod@^3.20.6": "zod@3.21.4"
     },
@@ -1029,6 +1029,10 @@
         "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
         "dependencies": {}
       },
+      "pg-pool@3.5.2": {
+        "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
+        "dependencies": {}
+      },
       "pg-pool@3.5.2_pg@8.9.0": {
         "integrity": "sha512-His3Fh17Z4eg7oANLob6ZvH8xIVen3phEZh2QuyrIl4dQSDVEabNducv6ysROKpDNPSD+12tONZVWfSgMvDD9w==",
         "dependencies": {
@@ -1041,6 +1045,20 @@
       },
       "pg-structure@7.13.1": {
         "integrity": "sha512-iDdBkWCcOK3fUWtdIfkrH06CNXZXL/R+rhDl4qQrMIXvrFckzzHax4bfSAFw39xwBXaijdvqA/Hyj655SKjlYA==",
+        "dependencies": {
+          "@typescript-plus/fast-memoize-decorator": "@typescript-plus/fast-memoize-decorator@0.1.0",
+          "dotenv": "dotenv@8.6.0",
+          "fast-memoize": "fast-memoize@2.5.2",
+          "indexable-array": "indexable-array@0.7.0",
+          "inflection": "inflection@1.13.4",
+          "json5": "json5@2.2.3",
+          "lodash.get": "lodash.get@4.4.2",
+          "pg": "pg@8.9.0",
+          "pg-connection-string": "pg-connection-string@2.5.0"
+        }
+      },
+      "pg-structure@7.14.0": {
+        "integrity": "sha512-Rq0IXxzRfK2KFYopjbJQKhKvWlcufzyG8wtFsR+2ncXl5NSg3YsQw1ODicIAtiU1vYFIdt/P3iQcGmJ/UrT6DQ==",
         "dependencies": {
           "@typescript-plus/fast-memoize-decorator": "@typescript-plus/fast-memoize-decorator@0.1.0",
           "dotenv": "dotenv@8.6.0",

--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -14,10 +14,6 @@ const logicalOperatorMapping: Record<'_and' | '_or', ConjunctionType> = {
 type ObjectClauseFields<Tkey extends string | number | symbol, TValue> =
   PartialRecord<Tkey, TValue>;
 
-export interface ClauseBuilderOptions {
-  preparedIndex: number;
-}
-
 export type WhereClauseInput<Tkey extends string | number | symbol, TValue> =
   & { [P in Tkey]?: TValue[] }
   & {
@@ -31,10 +27,9 @@ export class ClauseBuilder<T extends string | number | symbol> {
 
   constructor(
     private clause: WhereClauseInput<T, SupportedTypes>,
-    { preparedIndex }: ClauseBuilderOptions,
   ) {
     this.preparedValues = [];
-    this.preparedIndex = preparedIndex;
+    this.preparedIndex = 1;
   }
 
   private get nextPreparedIndex() {

--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -162,8 +162,19 @@ export class ClauseBuilder<T extends string | number | symbol> {
     this.whereClause.push(clause);
   }
 
+  private validateClauses() {
+    const { _and, _or, ...clauses } = this.clause;
+
+    if ((_and || _or) && (clauses && Object.keys(clauses).length)) {
+      throw new Error(
+        'Can\'t use a combination of flat field filter and _and / _or!',
+      );
+    }
+  }
+
   public buildWhereClause() {
     if (Object.keys(this.clause).length) {
+      this.validateClauses();
       this.buildOrClause();
       this.buildAndClause();
       this.buildClause();

--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -1,0 +1,182 @@
+import { SupportedTypes } from './types.ts';
+
+type PartialRecord<K extends keyof any, T> = {
+  [P in K]?: T;
+};
+
+type ConjunctionType = 'OR' | 'AND';
+type ArrayClauseFields<Tkey extends string | number | symbol, TValue> = Array<
+  PartialRecord<Tkey, TValue>
+>;
+type ObjectClauseFields<Tkey extends string | number | symbol, TValue> =
+  PartialRecord<Tkey, Array<TValue>>;
+
+export type ClauseFieldsGeneric<Tkey extends string | number | symbol, TValue> =
+  | ObjectClauseFields<Tkey, TValue>
+  | ArrayClauseFields<Tkey, TValue>;
+
+export interface ClauseBuilderOptions {
+  preparedIndex: number;
+  fallbackConjunction: ConjunctionType;
+}
+
+export interface WhereClauseInput<
+  TKey extends string | number | symbol,
+  TValue,
+> {
+  _or?: ClauseFieldsGeneric<TKey, TValue>;
+  _and?: ClauseFieldsGeneric<TKey, TValue>;
+  [key: string]: TValue[] | any;
+}
+
+// type WhereClauseFieldsInput = WhereClauseInput;
+// | { [K in Exclude<string, keyof WhereClauseInput>]: SupportedTypes[] };
+
+export class ClauseBuilder<T extends string | number | symbol> {
+  private fallbackConjunction: ConjunctionType;
+  private preparedIndex: number;
+  private preparedValues: Array<SupportedTypes>;
+  private whereClause: string[];
+
+  constructor(
+    private clause: WhereClauseInput<T, SupportedTypes>,
+    { preparedIndex, fallbackConjunction }: ClauseBuilderOptions,
+  ) {
+    this.preparedValues = [];
+    this.whereClause = [];
+    this.preparedIndex = preparedIndex;
+    this.fallbackConjunction = fallbackConjunction;
+  }
+
+  private get nextPreparedIndex() {
+    return this.preparedIndex + this.preparedValues.length;
+  }
+
+  private get whereClauseStr() {
+    if (!this.whereClause.length) {
+      return '';
+    }
+
+    if (this.whereClause.length === 1) {
+      return this.whereClause[0];
+    }
+
+    return this.whereClause.map((clause) => `(${clause})`).join(' AND ');
+  }
+
+  private buildArrayClause(
+    clauseFields: ArrayClauseFields<string, SupportedTypes>,
+    conjunction: ConjunctionType,
+    innerConjunction: ConjunctionType,
+  ) {
+    return clauseFields.map((field) => {
+      return Object.entries(field).map(([key, value]) => {
+        const sql = `"${key}" = $${this.nextPreparedIndex}`;
+
+        this.preparedValues.push(value);
+
+        return sql;
+      }).join(` ${innerConjunction} `);
+    }).map((clause) => `(${clause})`).join(` ${conjunction} `);
+  }
+
+  private buildObjectClause(
+    clauseFields: ObjectClauseFields<string, SupportedTypes>,
+    conjunction: ConjunctionType,
+  ) {
+    const clause = Object.entries(clauseFields).map(([key, values]) => {
+      const fields = values?.map((value) => {
+        const idx = `$${this.nextPreparedIndex}`;
+        this.preparedValues.push(value);
+        return idx;
+      }).join(', ');
+
+      return `"${key}" IN (${fields})`;
+    });
+
+    return `${clause.join(` ${conjunction} `)}`;
+  }
+
+  private buildArrayOrClause(
+    orClause: ArrayClauseFields<string, SupportedTypes>,
+  ) {
+    return this.buildArrayClause(orClause, 'OR', 'AND');
+  }
+
+  private buildObjectOrClause(
+    orClause: ObjectClauseFields<string, SupportedTypes>,
+  ) {
+    return this.buildObjectClause(orClause, 'OR');
+  }
+
+  private buildOrClause() {
+    const { _or } = this.clause;
+
+    if (!_or) {
+      return;
+    }
+
+    const clause = Array.isArray(_or)
+      ? this.buildArrayOrClause(_or)
+      : this.buildObjectOrClause(_or);
+
+    this.whereClause.push(clause);
+
+    return clause;
+  }
+
+  private buildArrayAndClause(
+    orClause: ArrayClauseFields<string, SupportedTypes>,
+  ) {
+    return this.buildArrayClause(orClause, 'AND', 'OR');
+  }
+
+  private buildObjectAndClause(
+    orClause: ObjectClauseFields<string, SupportedTypes>,
+  ) {
+    return this.buildObjectClause(orClause, 'AND');
+  }
+
+  private buildAndClause() {
+    const { _and } = this.clause;
+
+    if (!_and) {
+      return;
+    }
+
+    const clause = Array.isArray(_and)
+      ? this.buildArrayAndClause(_and)
+      : this.buildObjectAndClause(_and);
+
+    this.whereClause.push(clause);
+
+    return clause;
+  }
+
+  private buildClause() {
+    const { _and, _or, ...clauses } = this.clause;
+
+    if (!clauses || !Object.keys(clauses).length) {
+      return;
+    }
+
+    const clause = this.buildObjectClause(clauses, this.fallbackConjunction);
+
+    this.whereClause.push(clause);
+  }
+
+  public buildWhereClause() {
+    if (Object.keys(this.clause).length) {
+      this.buildOrClause();
+      this.buildAndClause();
+      this.buildClause();
+    }
+
+    return {
+      clause: this.whereClause,
+      clauseStr: this.whereClauseStr,
+      values: this.preparedValues,
+      nextPreparedIndex: this.nextPreparedIndex,
+    };
+  }
+}

--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -17,11 +17,6 @@ type ObjectClauseFields<Tkey extends string | number | symbol, TValue> =
 export interface ClauseBuilderOptions {
   preparedIndex: number;
 }
-// export interface WhereClauseInput<Tkey extends string | number | symbol, TValue> {
-//   _or?: WhereClauseInput<Tkey, TValue>[];
-//   _and?: WhereClauseInput<Tkey, TValue>[];
-//   [key: string]: TValue[] | any;
-// }
 
 export type WhereClauseInput<Tkey extends string | number | symbol, TValue> =
   & { [P in Tkey]?: TValue[] }
@@ -85,15 +80,12 @@ export class ClauseBuilder<T extends string | number | symbol> {
 
     const { _and, _or, ...fieldClauses } = firstClause;
 
-    const otherClause = otherClauses.length
-      ? this.buildClauses(otherClauses, conjunction, clauseQuery)
-      : '';
-    const _andClause = _and
-      ? this.buildClauses(_and, logicalOperatorMapping._and, clauseQuery)
-      : '';
-    const _orClause = _or
-      ? this.buildClauses(_or, logicalOperatorMapping._or, clauseQuery)
-      : '';
+    const otherClause = otherClauses.length &&
+      this.buildClauses(otherClauses, conjunction, clauseQuery);
+    const _andClause = _and &&
+      this.buildClauses(_and, logicalOperatorMapping._and, clauseQuery);
+    const _orClause = _or &&
+      this.buildClauses(_or, logicalOperatorMapping._or, clauseQuery);
 
     const fieldClause = Object.keys(fieldClauses).length
       ? this.buildObjectClause(fieldClauses, conjunction)

--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -29,9 +29,6 @@ export interface WhereClauseInput<
   [key: string]: TValue[] | any;
 }
 
-// type WhereClauseFieldsInput = WhereClauseInput;
-// | { [K in Exclude<string, keyof WhereClauseInput>]: SupportedTypes[] };
-
 export class ClauseBuilder<T extends string | number | symbol> {
   private fallbackConjunction: ConjunctionType;
   private preparedIndex: number;

--- a/src/clause-builder_test.ts
+++ b/src/clause-builder_test.ts
@@ -1,10 +1,6 @@
 import { assertEquals, describe, it } from './dev_deps.ts';
 
-import { ClauseBuilder, ClauseBuilderOptions } from './clause-builder.ts';
-
-const builderOptions: ClauseBuilderOptions = {
-  preparedIndex: 1,
-};
+import { ClauseBuilder } from './clause-builder.ts';
 
 describe('ClauseBuilder', () => {
   it(
@@ -14,7 +10,7 @@ describe('ClauseBuilder', () => {
         _and: [{ fieldOne: [1], fieldTwo: [2], fieldThree: [3] }],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -45,7 +41,7 @@ describe('ClauseBuilder', () => {
         }],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -64,7 +60,7 @@ describe('ClauseBuilder', () => {
         _or: [{ fieldOne: [1], fieldTwo: [2], fieldThree: [3] }],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -91,7 +87,7 @@ describe('ClauseBuilder', () => {
         }],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -111,7 +107,7 @@ describe('ClauseBuilder', () => {
         _or: [{ fieldThree: [3], fieldFour: [4] }],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -132,7 +128,7 @@ describe('ClauseBuilder', () => {
         fieldThree: [3],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =
@@ -162,7 +158,7 @@ describe('ClauseBuilder', () => {
         fieldNine: [9],
       };
 
-      const whereClause = new ClauseBuilder(filterClause, builderOptions)
+      const whereClause = new ClauseBuilder(filterClause)
         .buildWhereClause();
 
       const expectedClause =

--- a/src/clause-builder_test.ts
+++ b/src/clause-builder_test.ts
@@ -1,0 +1,184 @@
+import { assertEquals, describe, it } from './dev_deps.ts';
+
+import { ClauseBuilder, ClauseBuilderOptions } from './clause-builder.ts';
+
+const builderOptions: ClauseBuilderOptions = {
+  fallbackConjunction: 'AND',
+  preparedIndex: 1,
+};
+
+describe('ClauseBuilder', () => {
+  it(
+    'should return where clause when using array variant of _or with multiple fields',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _or: [{ fieldOne: 'value_one', fieldTwo: 10 }, {
+          fieldThree: 'value_two',
+          fieldFour: 20,
+        }],
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '("fieldOne" = $1 AND "fieldTwo" = $2) OR ("fieldThree" = $3 AND "fieldFour" = $4)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '("fieldOne" = $1 AND "fieldTwo" = $2) OR ("fieldThree" = $3 AND "fieldFour" = $4)',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 5);
+      assertEquals(whereClause.values, ['value_one', 10, 'value_two', 20]);
+    },
+  );
+
+  it(
+    'should return where clause when using map variant of _or with multiple fields',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _or: { fieldOne: ['value_one', 'value_two'], fieldTwo: [100, 50, 70] },
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '"fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '"fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 6);
+      assertEquals(whereClause.values, ['value_one', 'value_two', 100, 50, 70]);
+    },
+  );
+
+  it(
+    'should return where clause when using array variant of _and with multiple fields',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _and: [{ fieldOne: 'value_one', fieldTwo: 10 }, {
+          fieldThree: 'value_two',
+          fieldFour: 20,
+        }],
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '("fieldOne" = $1 OR "fieldTwo" = $2) AND ("fieldThree" = $3 OR "fieldFour" = $4)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '("fieldOne" = $1 OR "fieldTwo" = $2) AND ("fieldThree" = $3 OR "fieldFour" = $4)',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 5);
+      assertEquals(whereClause.values, ['value_one', 10, 'value_two', 20]);
+    },
+  );
+
+  it(
+    'should return where clause when using map variant of _and with multiple fields',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _and: { fieldOne: ['value_one', 'value_two'], fieldTwo: [100, 50, 70] },
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '"fieldOne" IN ($1, $2) AND "fieldTwo" IN ($3, $4, $5)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '"fieldOne" IN ($1, $2) AND "fieldTwo" IN ($3, $4, $5)',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 6);
+      assertEquals(whereClause.values, ['value_one', 'value_two', 100, 50, 70]);
+    },
+  );
+
+  it(
+    'should return where clause with combination of _and and _or',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _or: { fieldOne: ['value_one', 'value_two'], fieldTwo: [100, 50, 70] },
+        _and: { fieldOne: ['value_three'], fieldTwo: [1] },
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '"fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)',
+        '"fieldOne" IN ($6) AND "fieldTwo" IN ($7)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '("fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)) AND ("fieldOne" IN ($6) AND "fieldTwo" IN ($7))',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 8);
+      assertEquals(whereClause.values, [
+        'value_one',
+        'value_two',
+        100,
+        50,
+        70,
+        'value_three',
+        1,
+      ]);
+    },
+  );
+
+  it(
+    'should use fallback conjunction if missing _or and _and',
+    () => {
+      const whereClause = new ClauseBuilder({
+        fieldOne: ['value_one', 'value_two'],
+        fieldTwo: [100, 50, 70],
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '"fieldOne" IN ($1, $2) AND "fieldTwo" IN ($3, $4, $5)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '"fieldOne" IN ($1, $2) AND "fieldTwo" IN ($3, $4, $5)',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 6);
+      assertEquals(whereClause.values, [
+        'value_one',
+        'value_two',
+        100,
+        50,
+        70,
+      ]);
+    },
+  );
+
+  it(
+    'should use fallback conjunction if _or, _and and field value syntax is used',
+    () => {
+      const whereClause = new ClauseBuilder({
+        _or: { fieldOne: ['value_one', 'value_two'], fieldTwo: [100, 50, 70] },
+        _and: { fieldOne: ['value_three'], fieldTwo: [1] },
+        fieldOne: ['value_one', 'value_two'],
+        fieldTwo: [100, 50, 70],
+      }, builderOptions).buildWhereClause();
+
+      assertEquals(whereClause.clause, [
+        '"fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)',
+        '"fieldOne" IN ($6) AND "fieldTwo" IN ($7)',
+        '"fieldOne" IN ($8, $9) AND "fieldTwo" IN ($10, $11, $12)',
+      ]);
+      assertEquals(
+        whereClause.clauseStr,
+        '("fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)) AND ("fieldOne" IN ($6) AND "fieldTwo" IN ($7)) AND ("fieldOne" IN ($8, $9) AND "fieldTwo" IN ($10, $11, $12))',
+      );
+      assertEquals(whereClause.nextPreparedIndex, 13);
+      assertEquals(whereClause.values, [
+        'value_one',
+        'value_two',
+        100,
+        50,
+        70,
+        'value_three',
+        1,
+        'value_one',
+        'value_two',
+        100,
+        50,
+        70,
+      ]);
+    },
+  );
+});

--- a/src/clause-builder_test.ts
+++ b/src/clause-builder_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, describe, it } from './dev_deps.ts';
+import { assertEquals, assertThrows, describe, it } from './dev_deps.ts';
 
 import { ClauseBuilder, ClauseBuilderOptions } from './clause-builder.ts';
 
@@ -146,39 +146,20 @@ describe('ClauseBuilder', () => {
   );
 
   it(
-    'should use fallback conjunction if _or, _and and field value syntax is used',
+    'should throw error if _or, _and and field value syntax is used',
     () => {
-      const whereClause = new ClauseBuilder({
+      const clauseBuilder = new ClauseBuilder({
         _or: { fieldOne: ['value_one', 'value_two'], fieldTwo: [100, 50, 70] },
         _and: { fieldOne: ['value_three'], fieldTwo: [1] },
         fieldOne: ['value_one', 'value_two'],
         fieldTwo: [100, 50, 70],
-      }, builderOptions).buildWhereClause();
+      }, builderOptions);
 
-      assertEquals(whereClause.clause, [
-        '"fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)',
-        '"fieldOne" IN ($6) AND "fieldTwo" IN ($7)',
-        '"fieldOne" IN ($8, $9) AND "fieldTwo" IN ($10, $11, $12)',
-      ]);
-      assertEquals(
-        whereClause.clauseStr,
-        '("fieldOne" IN ($1, $2) OR "fieldTwo" IN ($3, $4, $5)) AND ("fieldOne" IN ($6) AND "fieldTwo" IN ($7)) AND ("fieldOne" IN ($8, $9) AND "fieldTwo" IN ($10, $11, $12))',
+      assertThrows(
+        () => clauseBuilder.buildWhereClause(),
+        Error,
+        'Can\'t use a combination of flat field filter and _and / _or!',
       );
-      assertEquals(whereClause.nextPreparedIndex, 13);
-      assertEquals(whereClause.values, [
-        'value_one',
-        'value_two',
-        100,
-        50,
-        70,
-        'value_three',
-        1,
-        'value_one',
-        'value_two',
-        100,
-        50,
-        70,
-      ]);
     },
   );
 });

--- a/src/dev_deps.ts
+++ b/src/dev_deps.ts
@@ -3,6 +3,8 @@ export {
   assertArrayIncludes,
   assertEquals,
   assertExists,
+  assertRejects,
+  assertThrows,
 } from 'https://deno.land/std@0.175.0/testing/asserts.ts';
 export {
   assertSpyCall,

--- a/src/norm.ts
+++ b/src/norm.ts
@@ -60,11 +60,11 @@ export class Norm<DbSchema extends SchemaBase> {
       selectOn,
     ).buildWhereClause();
 
-    const preparedQuery = `select (${
+    const preparedQuery = `select ${
       quoteAndJoin(
         selectColumns,
       )
-    }) from "${String(schema)}"."${String(tableName)}" where ${
+    } from "${String(schema)}"."${String(tableName)}" where ${
       whereClause || true
     };`;
 

--- a/src/norm.ts
+++ b/src/norm.ts
@@ -56,11 +56,12 @@ export class Norm<DbSchema extends SchemaBase> {
         DbSchema[S][T][keyof DbSchema[S][T]]
       >,
   ): Promise<Array<Pick<DbSchema[S][T], SC[number]>>> => {
-    const { clauseStr: whereClause, values: selectOnValues } =
-      new ClauseBuilder(selectOn, {
+    const { clause: whereClause, values: selectOnValues } = new ClauseBuilder(
+      selectOn,
+      {
         preparedIndex: 1,
-        fallbackConjunction: 'OR',
-      }).buildWhereClause();
+      },
+    ).buildWhereClause();
 
     const preparedQuery = `select (${
       quoteAndJoin(

--- a/src/norm.ts
+++ b/src/norm.ts
@@ -58,9 +58,6 @@ export class Norm<DbSchema extends SchemaBase> {
   ): Promise<Array<Pick<DbSchema[S][T], SC[number]>>> => {
     const { clause: whereClause, values: selectOnValues } = new ClauseBuilder(
       selectOn,
-      {
-        preparedIndex: 1,
-      },
     ).buildWhereClause();
 
     const preparedQuery = `select (${

--- a/src/norm.ts
+++ b/src/norm.ts
@@ -8,6 +8,7 @@ import {
 } from './types.ts';
 import { merge } from './deps.ts';
 import { SQLBuilder } from './sql-builder.ts';
+import { ClauseBuilder, WhereClauseInput } from './clause-builder.ts';
 export class Norm<DbSchema extends SchemaBase> {
   constructor(private dbClient: DBClient) {
   }
@@ -46,26 +47,20 @@ export class Norm<DbSchema extends SchemaBase> {
     schema: S,
     tableName: T,
     selectColumns: SC,
-    selectOn: {
-      [key in keyof DbSchema[S][T]]?: Array<DbSchema[S][T][key]>;
-    },
+    selectOn:
+      & {
+        [key in keyof DbSchema[S][T]]?: Array<DbSchema[S][T][key]>;
+      }
+      & WhereClauseInput<
+        keyof DbSchema[S][T],
+        DbSchema[S][T][keyof DbSchema[S][T]]
+      >,
   ): Promise<Array<Pick<DbSchema[S][T], SC[number]>>> => {
-    const selectOnColumns = Object.keys(selectOn) as Array<
-      keyof typeof selectOn
-    >;
-    const selectOnValues = Object.values(selectOn).flat();
-
-    const [_idx, whereClause] = selectOnColumns.reduce<[number, string]>(
-      ([previousIndex, query], column, curentIdx) => {
-        return [
-          previousIndex + (selectOn[column]?.length ?? 0),
-          `${query}${curentIdx > 0 ? ' OR ' : ''}"${String(column)}" in (${
-            selectOn[column]?.map((_, idx) => `$${idx + previousIndex}`)
-          })`,
-        ];
-      },
-      [1, ''],
-    );
+    const { clauseStr: whereClause, values: selectOnValues } =
+      new ClauseBuilder(selectOn, {
+        preparedIndex: 1,
+        fallbackConjunction: 'OR',
+      }).buildWhereClause();
 
     const preparedQuery = `select (${
       quoteAndJoin(

--- a/src/norm_test.ts
+++ b/src/norm_test.ts
@@ -35,7 +35,7 @@ describe('getEntities', () => {
 
       assertSpyCall(querySpy, 0, {
         args: [
-          'select ("id", "name", "countrycode") from "public"."city" where true;',
+          'select "id", "name", "countrycode" from "public"."city" where true;',
           [],
         ],
         returned: Promise.resolve({ rows: [] }),
@@ -59,7 +59,7 @@ describe('getEntities', () => {
       ], { id: [1] });
 
       const expectedSql =
-        'select ("id", "name", "countrycode") from "public"."city" where ("id" IN ($1));';
+        'select "id", "name", "countrycode" from "public"."city" where ("id" IN ($1));';
       const expectedValues = [1];
 
       assertEquals(expectedSql, querySpy.calls[0].args[0]);
@@ -83,7 +83,7 @@ describe('getEntities', () => {
       ], { name: ['name'], countrycode: ['countrycode'] });
 
       const expectedSql =
-        'select ("id", "name", "countrycode") from "public"."city" where ("name" IN ($1) AND "countrycode" IN ($2));';
+        'select "id", "name", "countrycode" from "public"."city" where ("name" IN ($1) AND "countrycode" IN ($2));';
       const expectedValues = ['name', 'countrycode'];
 
       assertEquals(expectedSql, querySpy.calls[0].args[0]);
@@ -115,7 +115,7 @@ describe('getEntities', () => {
       });
 
       const expectedSql =
-        'select ("id", "name", "countrycode") from "public"."city" where (("name" IN ($3) OR "countrycode" IN ($4)) OR ("name" IN ($1) OR "countrycode" IN ($2)));';
+        'select "id", "name", "countrycode" from "public"."city" where (("name" IN ($3) OR "countrycode" IN ($4)) OR ("name" IN ($1) OR "countrycode" IN ($2)));';
       const expectedValues = [
         'name_one',
         'countrycode_one',
@@ -156,7 +156,7 @@ describe('getEntities', () => {
       });
 
       const expectedSql =
-        'select ("id", "name", "countrycode", "district", "population") from "public"."city" where (("district" IN ($3) AND "countrycode" IN ($4)) OR ("district" IN ($1) AND "name" IN ($2)));';
+        'select "id", "name", "countrycode", "district", "population" from "public"."city" where (("district" IN ($3) AND "countrycode" IN ($4)) OR ("district" IN ($1) AND "name" IN ($2)));';
       const expectedValues = [
         'district_two',
         'name_two',
@@ -188,7 +188,7 @@ describe('getEntities', () => {
       });
 
       const expectedSql =
-        'select ("id", "name", "countrycode") from "public"."city" where (("population" IN ($3) OR "district" IN ($4)) AND ("name" IN ($1) AND "countrycode" IN ($2)));';
+        'select "id", "name", "countrycode" from "public"."city" where (("population" IN ($3) OR "district" IN ($4)) AND ("name" IN ($1) AND "countrycode" IN ($2)));';
       const expectedValues = [
         'name_three',
         'countrycode_three',
@@ -222,7 +222,7 @@ describe('getEntities', () => {
       });
 
       const expectedSql =
-        'select ("id", "name", "countrycode") from "public"."city" where ((("name" IN ($7) AND "countrycode" IN ($8)) AND ("id" IN ($3, $4) OR "name" IN ($5, $6))) AND ("name" IN ($1) AND "countrycode" IN ($2)));';
+        'select "id", "name", "countrycode" from "public"."city" where ((("name" IN ($7) AND "countrycode" IN ($8)) AND ("id" IN ($3, $4) OR "name" IN ($5, $6))) AND ("name" IN ($1) AND "countrycode" IN ($2)));';
       const expectedValues = [
         'name_four',
         'countrycode_two',


### PR DESCRIPTION
This PR adds the functionality to be able to handle more complex filtering when getting entities. This adds the following options to the selectOn clause
- `_and`
- `_or`

These options provide a recursive way of filtering similar to what is currently provided by hasura. For example , the filter below
```
{
  fieldOne: ['possible_value_fieldOne'],
  fieldTwo: ['possible_value_fieldTwo'],
  _and: [{ fieldThree: ['possible_value_fieldThree'], _or: [{ fieldFour: ['possible_value_fieldFour'], fieldFive: ['possible_value_fieldFive'] }] }]
}
```

would result in the following SQL

`select * from table where (("fieldOne" IN ($4) AND "fieldTwo" IN ($5)) AND (("fieldThree" IN ($3)) AND ("fieldFour" IN ($1) OR "fieldFive" IN ($2))))` with the prepared statement as 
```
[
  "possible_value_fieldFour",
  "possible_value_fieldFive",
  "possible_value_fieldThree",
  "possible_value_fieldOne",
  "possible_value_fieldTwo"
]
```