### PR TITLE
Operator support besides IN i.e. > or <

### DIFF
--- a/src/clause-builder.ts
+++ b/src/clause-builder.ts
@@ -48,19 +48,20 @@ export class ClauseBuilder<T extends string | number | symbol> {
     const clause = Object.entries(clauseFields).map(([key, values]) => {
       const fields = values?.map((fieldValue) => {
         if (fieldValue == null) {
-          // Handle the null or undefined fieldValue here. 
+          // Handle the null or undefined fieldValue here.
           return ''; // Currently just skips this iteration
         }
         // Check if the fieldValue includes an operator or is just a value
-        const { value, operator } = typeof fieldValue === 'object' && 'operator' in fieldValue
-          ? fieldValue
-          : { value: fieldValue, operator: 'IN' }; // Default to 'IN' if no operator is provided (to support legacy syntax)
-        
+        const { value, operator } =
+          typeof fieldValue === 'object' && 'operator' in fieldValue
+            ? fieldValue
+            : { value: fieldValue, operator: 'IN' }; // Default to 'IN' if no operator is provided (to support legacy syntax)
+
         const arrayValue = Array.isArray(value) ? value : [value];
 
         const idx = `$${this.nextPreparedIndex}`;
         this.preparedValues.push(value);
-  
+
         // Return the SQL fragment for this field, using the specified operator
         if (operator.toUpperCase() === 'IN') {
           // for the in operator make an array
@@ -71,10 +72,10 @@ export class ClauseBuilder<T extends string | number | symbol> {
           return `"${key}" ${operator} (${idx})`;
         }
       }).join(` ${conjunction} `);
-  
+
       return `${fields}`;
     });
-  
+
     return `(${clause.join(` ${conjunction} `)})`;
   }
 

--- a/src/clause-builder_test.ts
+++ b/src/clause-builder_test.ts
@@ -7,7 +7,11 @@ describe('ClauseBuilder', () => {
     'should return where clause when using only _and',
     () => {
       const filterClause = {
-        _and: [{ fieldOne: [{ value: 1, operator: 'IN'}], fieldTwo: [{ value: 2, operator: 'IN'}], fieldThree: [{ value: 3, operator: 'IN'}] }],
+        _and: [{
+          fieldOne: [{ value: 1, operator: 'IN' }],
+          fieldTwo: [{ value: 2, operator: 'IN' }],
+          fieldThree: [{ value: 3, operator: 'IN' }],
+        }],
       };
 
       const whereClause = new ClauseBuilder(filterClause)
@@ -184,7 +188,11 @@ describe('ClauseBuilder', () => {
     'should return where clause when using only _and with different operators',
     () => {
       const filterClause = {
-        _and: [{ fieldOne: [{ value: 1, operator: '>'}], fieldTwo: [{ value: 2, operator: '<'}], fieldThree: [{ value: 3, operator: '='}] }],
+        _and: [{
+          fieldOne: [{ value: 1, operator: '>' }],
+          fieldTwo: [{ value: 2, operator: '<' }],
+          fieldThree: [{ value: 3, operator: '=' }],
+        }],
       };
 
       const whereClause = new ClauseBuilder(filterClause)
@@ -202,5 +210,4 @@ describe('ClauseBuilder', () => {
       ]);
     },
   );
-  
 });

--- a/src/clause-builder_test.ts
+++ b/src/clause-builder_test.ts
@@ -7,7 +7,7 @@ describe('ClauseBuilder', () => {
     'should return where clause when using only _and',
     () => {
       const filterClause = {
-        _and: [{ fieldOne: [1], fieldTwo: [2], fieldThree: [3] }],
+        _and: [{ fieldOne: [{ value: 1, operator: 'IN'}], fieldTwo: [{ value: 2, operator: 'IN'}], fieldThree: [{ value: 3, operator: 'IN'}] }],
       };
 
       const whereClause = new ClauseBuilder(filterClause)
@@ -179,4 +179,28 @@ describe('ClauseBuilder', () => {
       ]);
     },
   );
+
+  it(
+    'should return where clause when using only _and with different operators',
+    () => {
+      const filterClause = {
+        _and: [{ fieldOne: [{ value: 1, operator: '>'}], fieldTwo: [{ value: 2, operator: '<'}], fieldThree: [{ value: 3, operator: '='}] }],
+      };
+
+      const whereClause = new ClauseBuilder(filterClause)
+        .buildWhereClause();
+
+      const expectedClause =
+        '("fieldOne" > ($1) AND "fieldTwo" < ($2) AND "fieldThree" = ($3))';
+
+      assertEquals(whereClause.clause, expectedClause);
+      assertEquals(whereClause.nextPreparedIndex, 4);
+      assertEquals(whereClause.values, [
+        1,
+        2,
+        3,
+      ]);
+    },
+  );
+  
 });


### PR DESCRIPTION
Modified clause builder to have additional optional operator parameter to specify operators besides IN. Defaults to IN if no operator is provided so tests still work.

Test added making sure additional operators work as intended.