### PR TITLE
bring back optionality when column has default value

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: v1.31.1
+          deno-version: v1.40.3
 
       - name: Verify formatting
         run: deno fmt --check
@@ -40,7 +40,7 @@ jobs:
       - name: Run linter
         run: deno lint
 
-      - name: Run Deno Check 
+      - name: Run Deno Check
         run: deno check src/mod.ts
 
       - name: Run tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "deno.enable": true,
   "deno.unstable": true,
   "deno.lint": true,
-  "deno.importMap": "import_map.jsonc"
+  "deno.importMap": "import_map.jsonc",
+  "editor.defaultFormatter": "denoland.vscode-deno"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
   "deno.unstable": true,
   "deno.lint": true,
   "deno.importMap": "import_map.jsonc",
-  "editor.defaultFormatter": "denoland.vscode-deno"
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -19,20 +19,16 @@
     }
   },
   "fmt": {
-    "files": {
-      "include": ["./"],
-      "exclude": [
-        "./testdata/",
-        "./npm/",
-        "src/test/fixtures/norm-schema.type.ts"
-      ]
-    },
-    "options": {
-      "useTabs": false,
-      "lineWidth": 80,
-      "indentWidth": 2,
-      "singleQuote": true,
-      "proseWrap": "preserve"
-    }
+    "include": ["./"],
+    "exclude": [
+      "./testdata/",
+      "./npm/",
+      "src/test/fixtures/norm-schema.type.ts"
+    ],
+    "useTabs": false,
+    "lineWidth": 80,
+    "indentWidth": 2,
+    "singleQuote": true,
+    "proseWrap": "preserve"
   }
 }

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -4,14 +4,12 @@
   },
 
   "lint": {
-    "files": {
-      "include": ["./"],
-      "exclude": [
-        "./testdata/",
-        "./npm/",
-        "src/test/fixtures/norm-schema.type.ts"
-      ]
-    },
+    "include": ["./"],
+    "exclude": [
+      "./testdata/",
+      "./npm/",
+      "src/test/fixtures/norm-schema.type.ts"
+    ],
     "rules": {
       "tags": ["recommended"],
       "include": ["ban-untagged-todo", "no-external-import"],

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -116,7 +116,7 @@ export class TypeGenerator {
       let typedColumnName = columnName;
       let columnType = `${info.type.type}`;
 
-      const isColumnOptional = info.nullable;
+      const isColumnOptional = info.nullable || info.hasDefaultValue;
 
       if (isColumnOptional) {
         typedColumnName = `${typedColumnName}?`;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ export type SupportedTypes =
   | string
   | boolean
   | Date
-  // deno-lint-ignore ban-types
   | object
   | null
   | undefined


### PR DESCRIPTION
Given that we couldn't track down why the change was made, I'm going to revert it to restore backwards compatibility with the older versions, so we can cut out a new release.